### PR TITLE
allow standalone usage

### DIFF
--- a/shml.sh
+++ b/shml.sh
@@ -278,6 +278,12 @@ function e {
 #SHML:END
 
 
+# Allow standalone usage
+if [ $# -gt 0 ] ; then
+  "$@"
+  exit
+fi
+
 # Usage / Examples
 ##
 if [[ "$(basename -- "$0")" = "shml.sh" ]]; then


### PR DESCRIPTION
This makes `shml color red` work without sourcing.
